### PR TITLE
Update .gitignore

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,9 @@
 # Descripción
 ¿Qué ha cambiado?
-
+Agregamos al gitignore soporte para Node.js
 - [ ] Frontend
 - [ ] Backend
-- [ ] Configuración del Server
+- [x] Configuración del Server
 
 # ¿Cómo puedo probar los cambios?
-¿En que URL y forma puedo ver el UPDATE?
+Por ejemplo, los archivos y la carpeta node_module ya no se suben al repo, ver el archivo .gitignore completo


### PR DESCRIPTION
# Descripción
Agregamos al gitignore soporte para Node.js

- [ ] Frontend
- [ ] Backend
- [x] Configuración del Server

# ¿Cómo puedo probar los cambios?
Por ejemplo, los archivos y la carpeta node_modules ya no se suben al repo, ver archivo .gitignore completo
